### PR TITLE
Fetch the authenticated user's id instead of USER environment variable

### DIFF
--- a/github.rb
+++ b/github.rb
@@ -5,13 +5,15 @@ require './okr'
 @client = Octokit::Client.new(:access_token => ENV['GITHUB_ACCESS_TOKEN'])
 @client.auto_paginate = true
 
+user_id = @client.user.login
+
 today = Date.today
 first = Date.new(today.year, today.month)
 last = Date.new(today.year, today.month).next_month - 1
 
 monthly_results = @client.list_issues('wantedly/infrastructure', {
   state: :all,
-  creator: ENV['USER'],
+  creator: user_id,
   labels: 'Monthly Result',
 }).map do |issue|
   "- #{issue.title} ##{issue.number}"
@@ -39,10 +41,10 @@ end
   'Weekly Goal': weekly_goal.join("\n"),
   'Daily Goal': daily_goal.join("\n"),
   'GitHub Activities': {
-    ':shipit: マージされた PR': "@wantedly+author:#{ENV['USER']}+merged",
-    ':memo: レビューしたor関わった PR': "@wantedly+-author:#{ENV['USER']}+commenter:#{ENV['USER']}+merged",
-    ':memo: 関わった&解決した Issue': "@wantedly+is:issue+commenter:#{ENV['USER']}+closed",
-    ':memo: 関わった&未解決の Issue': "@wantedly+is:issue+state:open+commenter:#{ENV['USER']}+updated",
+    ':shipit: マージされた PR': "@wantedly+author:#{user_id}+merged",
+    ':memo: レビューしたor関わった PR': "@wantedly+-author:#{user_id}+commenter:#{user_id}+merged",
+    ':memo: 関わった&解決した Issue': "@wantedly+is:issue+commenter:#{user_id}+closed",
+    ':memo: 関わった&未解決の Issue': "@wantedly+is:issue+state:open+commenter:#{user_id}+updated",
   }.map{|k,v| "- [#{k}](https://github.com/issues?q=#{v}:#{first}..#{last})"}.join("\n"),
   Description: 'WIP',
   Comment: 'WIP',


### PR DESCRIPTION
Use the [authenticated user's id](https://developer.github.com/v3/users/#get-the-authenticated-user) for further requests and links instead of `USER` environment variable.

Some people use different user names from GitHub ids. This PR makes it works for the cases.